### PR TITLE
docs: simplify MCP configuration to match community standards

### DIFF
--- a/.changeset/simplify-mcp-configuration.md
+++ b/.changeset/simplify-mcp-configuration.md
@@ -1,0 +1,13 @@
+---
+"act-testing-mcp": patch
+---
+
+Simplify MCP configuration to match community standards
+
+- Remove PROJECT_ROOT requirement from default configuration
+- Follow Browser MCP pattern with simple npx setup
+- Add PROJECT_ROOT as optional override for specific use cases
+- Update example configuration to be path-agnostic
+- Reference Browser MCP documentation for consistency
+
+This makes the setup much simpler for most users while still providing flexibility when needed. The new default configuration works out of the box without requiring project-specific paths, following established MCP community patterns.

--- a/README.md
+++ b/README.md
@@ -76,10 +76,7 @@ Add to your MCP configuration (e.g., `.cursor/mcp.json` for Cursor IDE):
   "mcpServers": {
     "act-testing": {
       "command": "npx",
-      "args": ["act-testing-mcp"],
-      "env": {
-        "PROJECT_ROOT": "/path/to/your/project"
-      }
+      "args": ["act-testing-mcp"]
     }
   }
 }
@@ -91,7 +88,20 @@ Add to your MCP configuration (e.g., `.cursor/mcp.json` for Cursor IDE):
 {
   "mcpServers": {
     "act-testing": {
-      "command": "act-testing-mcp",
+      "command": "act-testing-mcp"
+    }
+  }
+}
+```
+
+#### Option 3: With custom project path (if needed)
+
+```json
+{
+  "mcpServers": {
+    "act-testing": {
+      "command": "npx",
+      "args": ["act-testing-mcp"],
       "env": {
         "PROJECT_ROOT": "/path/to/your/project"
       }
@@ -100,7 +110,7 @@ Add to your MCP configuration (e.g., `.cursor/mcp.json` for Cursor IDE):
 }
 ```
 
-#### Option 3: Local development
+#### Option 4: Local development
 
 ```json
 {
@@ -117,7 +127,7 @@ Add to your MCP configuration (e.g., `.cursor/mcp.json` for Cursor IDE):
 }
 ```
 
-> **Note**: Using `npx` (Option 1) is recommended as it avoids PATH issues and ensures you always use the latest version. This resolves common NPX availability problems in IDEs as mentioned in [continuedev/continue#4791](https://github.com/continuedev/continue/issues/4791).
+> **Note**: Using `npx` (Option 1) is recommended as it avoids PATH issues and ensures you always use the latest version. The MCP server automatically detects the current working directory, so `PROJECT_ROOT` is only needed if you want to override the default behavior. This approach mirrors other MCP servers like [Browser MCP](https://docs.browsermcp.io/setup-server#cursor) and resolves common NPX availability problems as mentioned in [continuedev/continue#4791](https://github.com/continuedev/continue/issues/4791).
 
 ### Act Configuration
 

--- a/mcp-config.example.json
+++ b/mcp-config.example.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "act-testing": {
       "command": "npx",
-      "args": ["act-testing-mcp"],
-      "env": {
-        "PROJECT_ROOT": "/path/to/your/project"
-      }
+      "args": ["act-testing-mcp"]
     }
   }
 }


### PR DESCRIPTION
## Description

Simplifies the MCP configuration setup to follow community standards like Browser MCP, making it much easier for users to get started.

## Type of Change

- [x] 📚 Documentation update

## Related Issues

- References Browser MCP documentation pattern
- Addresses user experience improvements for MCP setup

## Changes Made

- Remove PROJECT_ROOT requirement from default configuration
- Follow Browser MCP pattern with simple npx setup
- Add PROJECT_ROOT as optional override for specific use cases  
- Update example configuration to be path-agnostic
- Reference Browser MCP documentation for consistency

## Testing

- [x] Documentation reviewed for accuracy
- [x] Example configuration validated  
- [x] Default setup tested without PROJECT_ROOT

## Benefits

- Much simpler setup for most users (just copy-paste config)
- Consistent with MCP ecosystem standards
- Less error-prone (no path configuration required)
- Works out of the box in most scenarios
- Still flexible for power users who need custom paths

This follows the same clean pattern used by Browser MCP and other popular MCP servers.