### PR TITLE
fix: enable CI workflow for bot-created PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main]
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize]
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
+  actions: write # Allow triggering workflows
   id-token: write # Required for npm provenance
 
 jobs:


### PR DESCRIPTION
## Description

Fixes the issue where CI workflows don't run on pull requests created by GitHub Actions bot (like changeset release PRs).

## Problem

PR #6 (changeset release PR) has no status checks running because GitHub has security restrictions that prevent workflows from automatically running on PRs created by GitHub Actions bots.

## Solution

- Add `pull_request_target` trigger to CI workflow to enable it for bot PRs
- Add `actions: write` permission to release workflow
- This ensures changeset release PRs get proper CI validation

## Type of Change

- [x] 🐛 Bug fix (workflow configuration)

## Testing

- [x] Workflow syntax validated
- [x] Will test on bot-created PR after merge

This resolves the security restriction issue while maintaining proper CI validation for all PRs including automated releases.