### PR TITLE
fix: ensure CI runs on bot-created PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,15 @@ on:
 
 jobs:
   test:
+    name: CI Tests and Checks
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # For pull_request_target, we need to checkout the PR head
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js 20
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

CI workflows are not running on bot-created PRs like the Changesets release PR (#9). This is due to GitHub's security restrictions on `pull_request_target` events.

## Solution

- **Add job name**: `CI Tests and Checks` for proper status check registration
- **Fix checkout**: Use `github.event.pull_request.head.sha` for `pull_request_target` events
- **Maintain security**: Only checkout the PR head, not base with elevated permissions

## Testing

This should allow CI to run on:
- ✅ Regular PRs (existing functionality)
- ✅ Bot-created PRs (Changesets, Dependabot, etc.)
- ✅ Status checks should appear in branch protection rules

## Related

- Fixes CI not running on PR #9 (Changesets release PR)
- Ensures proper status check registration for branch protection